### PR TITLE
Лабораторная работа № 10. Генерация адаптеров на “лету”. Компиляция кода адаптера и стратегия создания адаптера по интерфейсу.

### DIFF
--- a/spacebattle/SpaceBattle.Lib.Tests/CompileGameAdapterStrategyTest.cs
+++ b/spacebattle/SpaceBattle.Lib.Tests/CompileGameAdapterStrategyTest.cs
@@ -1,0 +1,58 @@
+﻿using System.Reflection;
+using Hwdtech;
+using Hwdtech.Ioc;
+
+namespace SpaceBattle.Lib.Tests;
+
+public class CompileGameAdapterStrategyTest
+{
+    public CompileGameAdapterStrategyTest()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "Scopes.Current.Set",
+            IoC.Resolve<object>(
+                "Scopes.New",
+                IoC.Resolve<object>("Scopes.Root")
+            )
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Compile",
+            (object[] args) => new CompileGameAdapterCommand((Type)args[0], (Type)args[1])
+        ).Execute();
+    }
+    [Fact]
+    public void SuccessfulAddingGameAdapterAssemblyAfterCompilation()
+    {
+        var typeObject = typeof(IUObject);
+        var typeTarget = typeof(ITurnable);
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.GenerateCode",
+            (object[] args) => ";"
+        ).Execute();
+
+        var currentAsm = Assembly.LoadFrom("SpaceBattle.Lib.Tests.dll");
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Code.Compile",
+            (object[] args) => currentAsm
+        ).Execute();
+
+        var asmDict = new Dictionary<KeyValuePair<Type, Type>, Assembly>();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Assemblies.Dictionary",
+            (object[] args) => asmDict
+        ).Execute();
+
+        IoC.Resolve<ICommand>("Game.Adapter.Compile", typeObject, typeTarget).Execute();
+
+        Assert.Single(asmDict);
+        Assert.Equal(new KeyValuePair<Type, Type>(typeObject, typeTarget), asmDict.First().Key);
+        Assert.Equal(currentAsm, asmDict.First().Value);
+    }
+}

--- a/spacebattle/SpaceBattle.Lib.Tests/CompileStringCodeStrategyTest.cs
+++ b/spacebattle/SpaceBattle.Lib.Tests/CompileStringCodeStrategyTest.cs
@@ -1,0 +1,64 @@
+﻿using System.Reflection;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Microsoft.CodeAnalysis;
+
+namespace SpaceBattle.Lib.Tests;
+
+public class CompileStringCodeStrategyTest
+{
+    public CompileStringCodeStrategyTest()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "Scopes.Current.Set",
+            IoC.Resolve<object>(
+                "Scopes.New",
+                IoC.Resolve<object>("Scopes.Root")
+            )
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Code.Compile",
+            (object[] args) => new CompileStringCodeStrategy().Init(args)
+        ).Execute();
+
+    }
+    [Fact]
+    public void SuccessfulCompilationStringCode()
+    {
+        var assemblyName = "String Code Compilation";
+        var references = new List<MetadataReference> {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(Assembly.LoadFrom("SpaceBattle.Lib.dll").Location)
+        };
+        var code = @"namespace SpaceBattle.Lib;
+                    public class FakeClass
+                    {
+                        static int Square(int n) => n * n;
+                    }";
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Code.Compile.AssemblyName",
+            (object[] args) => assemblyName
+        ).Execute();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Code.Compile.References",
+            (object[] args) => references
+        ).Execute();
+
+        var assembly = IoC.Resolve<Assembly>("Code.Compile", code);
+
+        var t = assembly.GetType("SpaceBattle.Lib.FakeClass");
+        var instance = Activator.CreateInstance(t!)!;
+
+        var square = t!.GetMethod("Square", BindingFlags.NonPublic | BindingFlags.Static);
+        var result = square?.Invoke(null, new object[] { 7 });
+
+        Assert.Equal("SpaceBattle.Lib.FakeClass", instance.GetType().ToString());
+        Assert.Equal(49, result);
+    }
+}

--- a/spacebattle/SpaceBattle.Lib.Tests/CreateGameAdapterStrategyTest.cs
+++ b/spacebattle/SpaceBattle.Lib.Tests/CreateGameAdapterStrategyTest.cs
@@ -1,0 +1,102 @@
+﻿using System.Reflection;
+using Hwdtech;
+using Hwdtech.Ioc;
+
+namespace SpaceBattle.Lib.Tests;
+
+public class CreateGameAdapterStrategyTest
+{
+    public CreateGameAdapterStrategyTest()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "Scopes.Current.Set",
+            IoC.Resolve<object>(
+                "Scopes.New",
+                IoC.Resolve<object>("Scopes.Root")
+            )
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Create",
+            (object[] args) => new CreateGameAdapterStrategy().Init(args)
+        ).Execute();
+    }
+    [Fact]
+    public void SuccessfulCreatingGameAdapterWithoutCompilation()
+    {
+        var uObject = new Mock<IUObject>();
+        var typeTarget = typeof(Type);
+
+        var asmDict = new Dictionary<KeyValuePair<Type, Type>, Assembly>
+        {
+            [new KeyValuePair<Type, Type>(uObject.Object.GetType(), typeTarget)] = Assembly.LoadFrom("SpaceBattle.Lib.Tests.dll")
+        };
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Assemblies.Dictionary",
+            (object[] args) => asmDict
+        ).Execute();
+
+        var compileCommand = new Mock<ICommand>();
+        compileCommand.Setup(cmd => cmd.Execute()).Verifiable();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Compile",
+            (object[] args) => compileCommand.Object
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Find",
+            (object[] args) => "foundAdapter"
+        ).Execute();
+
+        Assert.NotEmpty(asmDict);
+        compileCommand.Verify(x => x.Execute(), Times.Never());
+
+        var createdAdapter = IoC.Resolve<object>("Game.Adapter.Create", uObject.Object, typeTarget);
+
+        Assert.Equal("foundAdapter", createdAdapter);
+        compileCommand.Verify(x => x.Execute(), Times.Never());
+    }
+    [Fact]
+    public void SuccessfulCreatingGameAdapterWithCompilation()
+    {
+        var uObject = new Mock<IUObject>();
+        var typeTarget = typeof(Type);
+
+        var asmDict = new Dictionary<KeyValuePair<Type, Type>, Assembly>();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Assemblies.Dictionary",
+            (object[] args) => asmDict
+        ).Execute();
+
+        var compileCommand = new Mock<ICommand>();
+        var key = new KeyValuePair<Type, Type>(uObject.Object.GetType(), typeTarget);
+        var asm = new Mock<Assembly>().Object;
+        compileCommand.Setup(cmd => cmd.Execute()).Callback(() => asmDict.Add(key, asm)).Verifiable();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Compile",
+            (object[] args) => compileCommand.Object
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Find",
+            (object[] args) => "foundAdapter"
+        ).Execute();
+
+        Assert.Empty(asmDict);
+        compileCommand.Verify(x => x.Execute(), Times.Never());
+
+        var createdAdapter = IoC.Resolve<object>("Game.Adapter.Create", uObject.Object, typeTarget);
+
+        compileCommand.Verify(x => x.Execute(), Times.Once());
+        Assert.Single(asmDict);
+        Assert.Equal("foundAdapter", createdAdapter);
+    }
+}

--- a/spacebattle/SpaceBattle.Lib.Tests/FindGameAdapterStrategyTest.cs
+++ b/spacebattle/SpaceBattle.Lib.Tests/FindGameAdapterStrategyTest.cs
@@ -1,0 +1,91 @@
+﻿using System.Reflection;
+using Hwdtech;
+using Hwdtech.Ioc;
+using Microsoft.CodeAnalysis;
+
+namespace SpaceBattle.Lib.Tests;
+
+public class FindGameAdapterStrategyTest
+{
+    public FindGameAdapterStrategyTest()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "Scopes.Current.Set",
+            IoC.Resolve<object>(
+                "Scopes.New",
+                IoC.Resolve<object>("Scopes.Root")
+            )
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Code.Compile.AssemblyName",
+            (object[] args) => "Game Adapter Code Compilation"
+        ).Execute();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Code.Compile.References",
+            (object[] args) => new List<MetadataReference> {
+                            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                            MetadataReference.CreateFromFile(Assembly.LoadFrom("SpaceBattle.Lib.dll").Location)}
+        ).Execute();
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Code.Compile",
+            (object[] args) => new CompileStringCodeStrategy().Init(args)
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Name",
+            (object[] args) => args[0].ToString() + "Adapter"
+        ).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Find",
+            (object[] args) => new FindGameAdapterStrategy().Init(args)
+        ).Execute();
+    }
+    [Fact]
+    public void SuccessfulFindingGameAdapter()
+    {
+        var uObject = new Mock<IUObject>();
+        uObject.Setup(x => x.GetProperty("Angle")).Returns(new VectorAngle(60));
+
+        var targetType = typeof(ITurnable);
+
+        var adapterCode = @"namespace SpaceBattle.Lib;
+
+public class ITurnableAdapter : ITurnable
+{
+    private readonly IUObject _uObject;
+    public ITurnableAdapter(IUObject uObject)
+    {
+        _uObject = uObject;
+    }
+
+    public VectorAngle Angle { get => (VectorAngle)_uObject.GetProperty(""Angle""); 
+    set => _uObject.SetProperty(""Angle"", value); }
+
+    public VectorAngle DeltaAngle => (VectorAngle)_uObject.GetProperty(""DeltaAngle"");
+}
+        ";
+        var asmDict = new Dictionary<KeyValuePair<Type, Type>, Assembly>
+        {
+            [new KeyValuePair<Type, Type>(uObject.Object.GetType(), targetType)] = IoC.Resolve<Assembly>("Code.Compile", adapterCode)
+        };
+        IoC.Resolve<Hwdtech.ICommand>(
+            "IoC.Register",
+            "Game.Adapter.Assemblies.Dictionary",
+            (object[] args) => asmDict
+        ).Execute();
+
+        var adapter = (ITurnable)IoC.Resolve<object>("Game.Adapter.Find", uObject.Object, targetType);
+
+        Assert.NotNull(adapter);
+        Assert.Equal("ITurnableAdapter", adapter.GetType().Name);
+        Assert.Equal(new VectorAngle(60), adapter.Angle);
+    }
+}

--- a/spacebattle/SpaceBattle.Lib/CompileGameAdapterStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/CompileGameAdapterStrategy.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using Hwdtech;
+
+namespace SpaceBattle.Lib;
+
+public class CompileGameAdapterStrategy : IStrategy
+{
+    public object Init(params object[] args)
+    {
+        var typeObject = (Type)args[0];
+        var typeTarget = (Type)args[1];
+
+        return new CompileGameAdapterCommand(typeObject, typeTarget);
+    }
+}
+
+public class CompileGameAdapterCommand : ICommand
+{
+    private readonly Type _typeObject;
+    private readonly Type _typeTarget;
+    public CompileGameAdapterCommand(Type typeObject, Type typeTarget)
+    {
+        _typeObject = typeObject;
+        _typeTarget = typeTarget;
+    }
+    public void Execute()
+    {
+        var adapterCode = IoC.Resolve<string>("Game.Adapter.GenerateCode", _typeObject, _typeTarget);
+        var adapterAssembly = IoC.Resolve<Assembly>("Code.Compile", adapterCode);
+
+        var assemblyDictionary = IoC.Resolve<IDictionary<KeyValuePair<Type, Type>, Assembly>>("Game.Adapter.Assemblies.Dictionary");
+        var pairOfTypes = new KeyValuePair<Type, Type>(_typeObject, _typeTarget);
+
+        assemblyDictionary[pairOfTypes] = adapterAssembly;
+    }
+}

--- a/spacebattle/SpaceBattle.Lib/CompileGameAdapterStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/CompileGameAdapterStrategy.cs
@@ -31,6 +31,6 @@ public class CompileGameAdapterCommand : ICommand
         var assemblyDictionary = IoC.Resolve<IDictionary<KeyValuePair<Type, Type>, Assembly>>("Game.Adapter.Assemblies.Dictionary");
         var pairOfTypes = new KeyValuePair<Type, Type>(_typeObject, _typeTarget);
 
-        assemblyDictionary[pairOfTypes] = adapterAssembly;
+        assemblyDictionary.Add(pairOfTypes, adapterAssembly);
     }
 }

--- a/spacebattle/SpaceBattle.Lib/CompileGameAdapterStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/CompileGameAdapterStrategy.cs
@@ -3,17 +3,6 @@ using Hwdtech;
 
 namespace SpaceBattle.Lib;
 
-public class CompileGameAdapterStrategy : IStrategy
-{
-    public object Init(params object[] args)
-    {
-        var typeObject = (Type)args[0];
-        var typeTarget = (Type)args[1];
-
-        return new CompileGameAdapterCommand(typeObject, typeTarget);
-    }
-}
-
 public class CompileGameAdapterCommand : ICommand
 {
     private readonly Type _typeObject;

--- a/spacebattle/SpaceBattle.Lib/CompileStringCodeStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/CompileStringCodeStrategy.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using Hwdtech;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace SpaceBattle.Lib;
+
+public class CompileStringCodeStrategy : IStrategy
+{
+    public object Init(params object[] args)
+    {
+        var codeString = (string)args[0];
+
+        var name = IoC.Resolve<string>("Code.Compile.AssemblyName");
+        var references = IoC.Resolve<IEnumerable<MetadataReference>>("Code.Compile.References");
+        var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        var syntaxTree = CSharpSyntaxTree.ParseText(codeString);
+
+        var compilation = CSharpCompilation.Create(name)
+            .WithOptions(options)
+            .AddReferences(references)
+            .AddSyntaxTrees(syntaxTree);
+
+        Assembly assembly;
+
+        using (var ms = new MemoryStream())
+        {
+            var result = compilation.Emit(ms);
+            ms.Seek(0, SeekOrigin.Begin);
+            assembly = Assembly.Load(ms.ToArray());
+        }
+
+        return assembly;
+    }
+}

--- a/spacebattle/SpaceBattle.Lib/CreateGameAdapterStrategy,cs
+++ b/spacebattle/SpaceBattle.Lib/CreateGameAdapterStrategy,cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Hwdtech;
+
+namespace SpaceGame.Lib;
+
+public class CreateGameAdapterStrategy : IStrategy
+{
+    public object Init(params object[] args)
+    {
+        var uObject = (IUObject)args[0];
+        var typeTarget = (Type)args[1];
+
+        var assemblyDictionary = IoC.Resolve<IDictionary<KeyValuePair<Type, Type>, Assembly>>("Game.Adapter.Assemblies.Dictionary");
+        var pairOfTypes = new KeyValuePair<Type, Type>(uObject.GetType(), typeTarget);
+
+        if (!adapterAssemblyMap.TryGetValue(pair, out var assembly))
+        {
+            IoC.Resolve<ICommand>("Game.Adapter.Compile", uObject.GetType(), typeTarget).Execute();
+        }
+
+        return IoC.Resolve<object>("Game.Adapter.Find", uObject, typeTarget);
+    }
+}

--- a/spacebattle/SpaceBattle.Lib/CreateGameAdapterStrategy,cs
+++ b/spacebattle/SpaceBattle.Lib/CreateGameAdapterStrategy,cs
@@ -13,7 +13,7 @@ public class CreateGameAdapterStrategy : IStrategy
         var assemblyDictionary = IoC.Resolve<IDictionary<KeyValuePair<Type, Type>, Assembly>>("Game.Adapter.Assemblies.Dictionary");
         var pairOfTypes = new KeyValuePair<Type, Type>(uObject.GetType(), typeTarget);
 
-        if (!adapterAssemblyMap.TryGetValue(pair, out var assembly))
+        if (!assemblyDictionary.ContainsKey(pairOfTypes))
         {
             IoC.Resolve<ICommand>("Game.Adapter.Compile", uObject.GetType(), typeTarget).Execute();
         }

--- a/spacebattle/SpaceBattle.Lib/CreateGameAdapterStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/CreateGameAdapterStrategy.cs
@@ -1,7 +1,7 @@
-using System.Reflection;
+﻿using System.Reflection;
 using Hwdtech;
 
-namespace SpaceGame.Lib;
+namespace SpaceBattle.Lib;
 
 public class CreateGameAdapterStrategy : IStrategy
 {

--- a/spacebattle/SpaceBattle.Lib/FindGameAdapterStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/FindGameAdapterStrategy.cs
@@ -1,8 +1,7 @@
 ﻿using System.Reflection;
 using Hwdtech;
-using SpaceBattle.Lib;
 
-namespace SpaceGame.Lib;
+namespace SpaceBattle.Lib;
 
 public class FindGameAdapterStrategy : IStrategy
 {
@@ -15,8 +14,8 @@ public class FindGameAdapterStrategy : IStrategy
         var pairOfTypes = new KeyValuePair<Type, Type>(uObject.GetType(), typeTarget);
         var assembly = assemblyDictionary[pairOfTypes];
 
-        var type = assembly.GetType(IoC.Resolve<string>("Game.Adapter.AssemblyName", typeTarget));
-        
+        var type = assembly.GetType(IoC.Resolve<string>("Game.Adapter.Name", typeTarget));
+
         return Activator.CreateInstance(type!, uObject)!;
     }
 }

--- a/spacebattle/SpaceBattle.Lib/FindGameAdapterStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/FindGameAdapterStrategy.cs
@@ -13,10 +13,10 @@ public class FindGameAdapterStrategy : IStrategy
 
         var assemblyDictionary = IoC.Resolve<IDictionary<KeyValuePair<Type, Type>, Assembly>>("Game.Adapter.Assemblies.Dictionary");
         var pairOfTypes = new KeyValuePair<Type, Type>(uObject.GetType(), typeTarget);
-
         var assembly = assemblyDictionary[pairOfTypes];
-        var type = assembly.GetType(IoC.Resolve<string>("Game.Adapter.AssemblyName", typeTarget))!;
 
-        return Activator.CreateInstance(type)!;
+        var type = assembly.GetType(IoC.Resolve<string>("Game.Adapter.AssemblyName", typeTarget));
+        
+        return Activator.CreateInstance(type!, uObject)!;
     }
 }

--- a/spacebattle/SpaceBattle.Lib/FindGameAdapterStrategy.cs
+++ b/spacebattle/SpaceBattle.Lib/FindGameAdapterStrategy.cs
@@ -1,0 +1,22 @@
+﻿using System.Reflection;
+using Hwdtech;
+using SpaceBattle.Lib;
+
+namespace SpaceGame.Lib;
+
+public class FindGameAdapterStrategy : IStrategy
+{
+    public object Init(params object[] args)
+    {
+        var uObject = (IUObject)args[0];
+        var typeTarget = (Type)args[1];
+
+        var assemblyDictionary = IoC.Resolve<IDictionary<KeyValuePair<Type, Type>, Assembly>>("Game.Adapter.Assemblies.Dictionary");
+        var pairOfTypes = new KeyValuePair<Type, Type>(uObject.GetType(), typeTarget);
+
+        var assembly = assemblyDictionary[pairOfTypes];
+        var type = assembly.GetType(IoC.Resolve<string>("Game.Adapter.AssemblyName", typeTarget))!;
+
+        return Activator.CreateInstance(type)!;
+    }
+}

--- a/spacebattle/SpaceBattle.Lib/SpaceBattle.Lib.csproj
+++ b/spacebattle/SpaceBattle.Lib/SpaceBattle.Lib.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -9,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Hwdtech.Core" Version="1.0.0" />
     <PackageReference Include="Hwdtech.Ioc.ScopeBasedIoCImplementation" Version="1.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Ряд команд, реализующих поведение космического корабля и других игровых объектов, устроены следующим образом:
<pre><code>class SomeCommand: ICommand
{
	private CommandTarget target;
	public SomeCommand(CommandTarget target) => this.target = target;
	public void Execute()
	{
		// реализация команды, которая обращается к объекту target.
	}
} 
</pre></code>
Часто получение объекта такой Команды выполняется с помощью следующего кода: <pre><code>IoC.Resolve<ICommand>(“SomeCommand”, obj);</pre></code>где obj - объект, для которого будет выполнена создаваемая Команда. При этом стратегия для разрешения зависимости определяется следующим образом.
<pre><code>IoC.Resolve<ICommand>(
“IoC.Register”,
“SomeCommand”,
(Func<object[], object>)(args) => {
	var adapter = IoC.Resolve<SomeCommandTarget>(“Adapter for SomeCommandTarget”, args[0]);
        return new SomeCommand(adapter); }
).Execute();
 
IoC.Resolve<ICommand>(
“IoC.Register”,
“Adapter for SomeCommandTarget”,
(Func<object[], object>)(args) => return new SomeCommandTargetAdapter(args[0])}
).Execute(); 
</pre></code>
Для разных команд этот код отличается только типами самой команды SomeCommand, SomeCommandTarget и необходимостью написания класса SomeCommandTargetAdapter.

Если бы не класс SomeCommandTargetAdapter, то можно было бы обобщить данную стратегию до одного класса и избавиться от необходимости дублирования данного кода. Если использовать кодогенерацию и рефлексию, то можно этот класс сгенерировать автоматически, используя лишь определение интерфейса SomeCommandTarget.

**_Задачи:_**
2.  Компиляция кода адаптера и стратегия создания адаптера по интерфейсу.
